### PR TITLE
fix typos

### DIFF
--- a/docs/Building duktape from github.md
+++ b/docs/Building duktape from github.md
@@ -1,8 +1,8 @@
 # Building duktape from Github
-To use the latest versions of Duktape, we will want to build our own version from a release ofthe
+To use the latest versions of Duktape, we will want to build our own version from a release of the
 source contained on Github.  Here is the recipe.
 
-1. Visit the release/build site for Dukatpe found here
+1. Visit the release/build site for Duktape found here
 
 [https://github.com/svaarala/duktape/releases]
 


### PR DESCRIPTION
This is just a couple typo fixes.

Another issue is that the "latest release" of duktape available at https://github.com/svaarala/duktape/releases is 1.8.1. These instructions do not work with duktape 1.8.1.

I've followed the instructions, but I'm not sure what to do next. I've tried various incantations of `make` without success.