### PR TITLE
fix application/x-www-form-urlencoded decoding; closes #19

### DIFF
--- a/filesystem/url.js
+++ b/filesystem/url.js
@@ -64,13 +64,12 @@ module.exports = {
 	 * use a RegExp.
 	 */
 	queryParse: function(queryString) {
-		var parts = decodeURIComponent(queryString).split("&");
+		var parts = decodeURIComponent(queryString.replace(/\+/g, '%20')).split("&");
 		var result = {};
 		var i;
 		for (i=0; i<parts.length; i++) {
 			var nameValue = parts[i].split("=");
-			// We need to decode the values
-			result[nameValue[0]] = decodeURIComponent(nameValue[1]);
+			result[nameValue[0]] = nameValue[1];
 		}
 		return result;
 	} // queryParse


### PR DESCRIPTION
calling `decodeURIComponent()` more than once seems like a bug to me.

I'll see about updating the tests too, but `mkspiffs` was complaining (ostensibly about pathname length), so I took the `tests/` dir out of the fs.  not sure what's wrong there, but my `mkspiffs` version is `0.2.0`.