### PR TITLE
Changing optional configure paths

### DIFF
--- a/docs/Building duktape from github.md
+++ b/docs/Building duktape from github.md
@@ -49,8 +49,8 @@ but instead run on the WROVER ESP32 module.
 python tools/configure.py \
     --config-metadata config/ \
     --source-directory src-input \
-    --option-file components/duktape/config/examples/low_memory.yaml \
-    --option-file data/duktape/ESP32-Duktape.yaml \
+    --option-file config/examples/low_memory.yaml \
+    --option-file ../../data/duktape/ESP32-Duktape.yaml \
     --output-directory src
 ```
 


### PR DESCRIPTION
Without the changes in the paths, I wasn't able to run configure.py, since most of the files were located at duktape-esp32/components/duktape.