### PR TITLE
Missing semicolons and AES encryption functions update

### DIFF
--- a/components/espfs/espfs.c
+++ b/components/espfs/espfs.c
@@ -142,7 +142,7 @@ EspFsFile *espFsOpen(const char *fileName) {
 			flashAddress += 4-((int)flashAddress & 3); //align to next 32bit val
 		}
 	}
-	ESP_LOGD(tag, "<< espFsOpen")
+	ESP_LOGD(tag, "<< espFsOpen");
 } // espFsOpen
 
 //Read len bytes from the given file into buff. Returns the actual amount of bytes read.

--- a/main/module_aes.c
+++ b/main/module_aes.c
@@ -180,7 +180,7 @@ static duk_ret_t js_fast_aes_wrap(duk_context *ctx) {
 	for (i = 1; i <= n; i++) {
 			os_memcpy(b, a, 8);
 			os_memcpy(b + 8, r, 8);
-			mbedtls_aes_encrypt(&aes_ctx, b, b);
+			esp_internal_aes_encrypt(&aes_ctx, b, b);
 			os_memcpy(a, b, 8);
 			a[7] ^= n * j + i;
 			os_memcpy(r, b + 8, 8);
@@ -249,7 +249,7 @@ static duk_ret_t js_fast_aes_unwrap(duk_context *ctx) {
 			os_memcpy(b, a, 8);
 			b[7] ^= n * j + i;
 			os_memcpy(b + 8, r, 8);
-			mbedtls_aes_decrypt(&aes_ctx, b, b);
+			esp_internal_aes_decrypt(&aes_ctx, b, b);
 			os_memcpy(a, b, 8);
 			os_memcpy(r, b + 8, 8);
 			r -= 8;

--- a/main/module_rmt.c
+++ b/main/module_rmt.c
@@ -168,7 +168,7 @@ static duk_ret_t js_rmt_write(duk_context *ctx) {
 
 		LOGD("Length of RMT data item array is %d", dataItemCount);
 		if (dataItemCount == 0) {
-			LOGD("<< jms_rmt_write - length of items is 0")
+			LOGD("<< jms_rmt_write - length of items is 0");
 			return 0;
 		}
 


### PR DESCRIPTION
The current version of esp-idf uses the functions "esp_internal_aes_encrypt" and "esp_internal_aes_decrypt" instead of "mbedtls_aes_encrypt" and "mbedtls_aes_decrypt" and fixed some missing semicolons.